### PR TITLE
Added structure for C and C++ articles

### DIFF
--- a/src/.vitepress/config.mts
+++ b/src/.vitepress/config.mts
@@ -16,6 +16,18 @@ export default defineConfig({
             {
                 text: "Resources",
                 items: [
+                    {
+                        text: "C", items: [
+                            { text: "Getting Started with C", link: "/resources/c/getting-started" },
+                        ],
+                        collapsed: true,
+                    },
+                    {
+                        text: "C++", items: [
+                            { text: "Getting Started with C++", link: "/resources/cpp/getting-started" },
+                        ],
+                        collapsed: true,
+                    },
                     { text: "Markdown Examples", link: "/resources/markdown-examples" },
                     { text: "Runtime API Examples", link: "/resources/api-examples" },
                 ],

--- a/src/resources/c/getting-started.md
+++ b/src/resources/c/getting-started.md
@@ -1,0 +1,1 @@
+# Getting Started with C

--- a/src/resources/cpp/getting-started.md
+++ b/src/resources/cpp/getting-started.md
@@ -1,0 +1,1 @@
+# Getting Started with C++


### PR DESCRIPTION
Change to Sidebar:

![image](https://github.com/user-attachments/assets/d3228ef2-5a4f-4019-92ae-a16c50420a2c)

This should allow for easy placement of new articles in the future.