### PR TITLE
Add InlineIcon vue component

### DIFF
--- a/src/components/tccpp/components/InlineIcon.vue
+++ b/src/components/tccpp/components/InlineIcon.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+const props = defineProps<{
+    src: string;
+    alt?: string;
+}>();
+</script>
+
+<style module>
+.inline_icon {
+    width: 14pt;
+    display: inline;
+}
+</style>
+
+<template>
+    <img v-bind="props" :class="$style.inline_icon" />
+</template>


### PR DESCRIPTION
This PR adds a basic Vue component to easily generate inline icons from.

Markup:
```md
<InlineIcon src="/assets/vs-code-icon.webp" alt="VS Code icon" /> **VS Code** is a text editor
```

Result:
![image](https://github.com/user-attachments/assets/8cd983ef-59bf-4556-b058-4402a1e5e794)
