### PR TITLE
Add a markdown plugin for custom wiki articles

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npx lint-staged
+npm run test

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,7 @@ build: prereqs ## Builds the website
 .PHONY: format
 format: prereqs ## Format files
 	npm run format
+
+.PHONY: test
+test: prereqs ## runs tests
+	npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
                 "@fortawesome/free-brands-svg-icons": "^6.7.2",
                 "@fortawesome/free-solid-svg-icons": "^6.7.2",
                 "@fortawesome/vue-fontawesome": "^3.0.8",
+                "markdown-it": "^14.1.0",
                 "markdown-it-footnote": "^4.0.0",
                 "markdown-it-mathjax3": "^4.3.2"
             },
@@ -2402,8 +2403,7 @@
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/assertion-error": {
             "version": "2.0.1",
@@ -3749,6 +3749,14 @@
                 "url": "https://github.com/sponsors/antonk52"
             }
         },
+        "node_modules/linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "dependencies": {
+                "uc.micro": "^2.0.0"
+            }
+        },
         "node_modules/lint-staged": {
             "version": "15.5.0",
             "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.0.tgz",
@@ -3917,6 +3925,22 @@
             "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
             "dev": true
         },
+        "node_modules/markdown-it": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
         "node_modules/markdown-it-footnote": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
@@ -3962,6 +3986,11 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
+        },
+        "node_modules/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
         },
         "node_modules/mensch": {
             "version": "0.3.4",
@@ -4504,6 +4533,14 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
             "engines": {
                 "node": ">=6"
             }
@@ -5105,6 +5142,11 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "node_modules/uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
         },
         "node_modules/undici-types": {
             "version": "6.20.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "lint-files": "eslint --color",
         "format": "prettier . --write",
         "format-check": "prettier . --check",
-        "format-files": "prettier . --write --ignore-unknown"
+        "format-files": "prettier . --write --ignore-unknown",
+        "test": "vitest run"
     },
     "devDependencies": {
         "@types/node": "^22.13.10",
@@ -29,6 +30,7 @@
         "@fortawesome/free-brands-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/vue-fontawesome": "^3.0.8",
+        "markdown-it": "^14.1.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-mathjax3": "^4.3.2"
     }

--- a/src/.vitepress/config.mts
+++ b/src/.vitepress/config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitepress";
 import footnote from "markdown-it-footnote";
+import { wiki_icons_plugin } from "../components/markdown/wiki-icons";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -214,6 +215,7 @@ export default defineConfig({
         math: true,
         config: md => {
             md.use(footnote);
+            md.use(wiki_icons_plugin);
         },
     },
     cleanUrls: true,

--- a/src/components/markdown/wiki-icons.ts
+++ b/src/components/markdown/wiki-icons.ts
@@ -1,0 +1,90 @@
+import assert from "assert";
+import MarkdownIt from "markdown-it";
+import { Token } from "markdown-it/index.js";
+import StateCore from "markdown-it/lib/rules_core/state_core.mjs";
+
+// based on markdown-it-emoji
+
+const ICONS = {
+    cpp: "c++.svg",
+    c: "c.svg",
+};
+
+const ICON_PATH = "assets/icons";
+
+function regex_escape(str: string) {
+    return str.replace(/[.?*+^$[\]\\(){}|-]/g, "\\$&");
+}
+
+export const icon_re = new RegExp(
+    Object.keys(ICONS)
+        .map(name => `:${name}:`)
+        .map(regex_escape)
+        .join("|"),
+);
+export const icon_re_global = new RegExp(icon_re.source, "g");
+
+function split_text_token(text: string, level: number, Token: StateCore["Token"]) {
+    let last_pos = 0;
+    const nodes: Token[] = [];
+
+    for (const { 0: match, index } of text.matchAll(icon_re_global)) {
+        let icon_name = match.slice(1, -1);
+        // Add new tokens to pending list
+        if (index > last_pos) {
+            const token = new Token("text", "", 0);
+            token.content = text.slice(last_pos, index);
+            nodes.push(token);
+        }
+
+        const token = new Token("wiki_icon", "", 0);
+        token.markup = icon_name;
+        token.meta = {
+            path: `/${ICON_PATH}/${ICONS[icon_name]}`,
+            alt: icon_name,
+        };
+        nodes.push(token);
+
+        last_pos = index + match.length;
+    }
+
+    if (last_pos < text.length) {
+        const token = new Token("text", "", 0);
+        token.content = text.slice(last_pos);
+        nodes.push(token);
+    }
+
+    return nodes;
+}
+
+export const wiki_icons_plugin = (md: MarkdownIt) => {
+    md.renderer.rules.wiki_icon = function (tokens, idx /*, options, env */) {
+        return `<InlineIcon src="${tokens[idx].meta.path}" alt="${tokens[idx].meta.alt}" />`;
+    };
+    md.core.ruler.after("linkify", "wiki_icon", function (state) {
+        const blockTokens = state.tokens;
+        let auto_link_level = 0;
+        for (let j = 0, l = blockTokens.length; j < l; j++) {
+            if (blockTokens[j].type !== "inline") {
+                continue;
+            }
+            let tokens = blockTokens[j].children;
+            assert(tokens);
+            // scan from end to keep position when tokens are added
+            for (let i = tokens.length - 1; i >= 0; i--) {
+                const token: Token = tokens[i];
+                if ((token.type === "link_open" || token.type === "link_close") && token.info === "auto") {
+                    auto_link_level += token.nesting;
+                }
+                if (token.type === "text" && auto_link_level === 0 && icon_re.test(token.content)) {
+                    // replace current node
+                    blockTokens[j].children = tokens = md.utils.arrayReplaceAt(
+                        tokens,
+                        i,
+                        split_text_token(token.content, token.level, state.Token),
+                    );
+                }
+            }
+        }
+    });
+};

--- a/test/markdown/utils.ts
+++ b/test/markdown/utils.ts
@@ -1,0 +1,10 @@
+import { Token } from "markdown-it/index.js";
+
+export function reduce(tokens: Token[] | null) {
+    if (tokens === null) {
+        return null;
+    }
+    return tokens.map(({ type, content, meta, children }) =>
+        meta ? { type, content, meta, children: reduce(children) } : { type, content, children: reduce(children) },
+    );
+}

--- a/test/markdown/wiki-icons.test.ts
+++ b/test/markdown/wiki-icons.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "vitest";
+import MarkdownIt from "markdown-it";
+import { wiki_icons_plugin } from "../../src/components/markdown/wiki-icons";
+import { reduce } from "./utils";
+
+describe("nobr tests", () => {
+    test("nothing", () => {
+        const md = MarkdownIt();
+        md.use(wiki_icons_plugin);
+        const result = md.parse("test c++ test", {});
+        expect(reduce(result)).to.deep.equal([
+            {
+                children: null,
+                content: "",
+                type: "paragraph_open",
+            },
+            {
+                children: [
+                    {
+                        children: null,
+                        content: "test c++ test",
+                        type: "text",
+                    },
+                ],
+                content: "test c++ test",
+                type: "inline",
+            },
+            {
+                children: null,
+                content: "",
+                type: "paragraph_close",
+            },
+        ]);
+    });
+    test("basic", () => {
+        const md = MarkdownIt();
+        md.use(wiki_icons_plugin);
+        const result = md.parse("test :cpp: :c: test", {});
+        expect(reduce(result)).to.deep.equal([
+            {
+                children: null,
+                content: "",
+                type: "paragraph_open",
+            },
+            {
+                children: [
+                    {
+                        children: null,
+                        content: "test ",
+                        type: "text",
+                    },
+                    {
+                        children: null,
+                        content: "",
+                        meta: {
+                            alt: "cpp",
+                            path: "/assets/icons/c++.svg",
+                        },
+                        type: "wiki_icon",
+                    },
+                    {
+                        children: null,
+                        content: " ",
+                        type: "text",
+                    },
+                    {
+                        children: null,
+                        content: "",
+                        meta: {
+                            alt: "c",
+                            path: "/assets/icons/c.svg",
+                        },
+                        type: "wiki_icon",
+                    },
+                    {
+                        children: null,
+                        content: " test",
+                        type: "text",
+                    },
+                ],
+                content: "test :cpp: :c: test",
+                type: "inline",
+            },
+            {
+                children: null,
+                content: "",
+                type: "paragraph_close",
+            },
+        ]);
+    });
+    test("more elaborate", () => {
+        const md = MarkdownIt();
+        md.use(wiki_icons_plugin);
+        const result = md.parse("Test :cpp: test test:cpp: :cpp:test", {});
+        expect(reduce(result)).to.deep.equal([
+            {
+                children: null,
+                content: "",
+                type: "paragraph_open",
+            },
+            {
+                children: [
+                    {
+                        children: null,
+                        content: "Test ",
+                        type: "text",
+                    },
+                    {
+                        children: null,
+                        content: "",
+                        meta: {
+                            alt: "cpp",
+                            path: "/assets/icons/c++.svg",
+                        },
+                        type: "wiki_icon",
+                    },
+                    {
+                        children: null,
+                        content: " test test",
+                        type: "text",
+                    },
+                    {
+                        children: null,
+                        content: "",
+                        meta: {
+                            alt: "cpp",
+                            path: "/assets/icons/c++.svg",
+                        },
+                        type: "wiki_icon",
+                    },
+                    {
+                        children: null,
+                        content: " ",
+                        type: "text",
+                    },
+                    {
+                        children: null,
+                        content: "",
+                        meta: {
+                            alt: "cpp",
+                            path: "/assets/icons/c++.svg",
+                        },
+                        type: "wiki_icon",
+                    },
+                    {
+                        children: null,
+                        content: "test",
+                        type: "text",
+                    },
+                ],
+                content: "Test :cpp: test test:cpp: :cpp:test",
+                type: "inline",
+            },
+            {
+                children: null,
+                content: "",
+                type: "paragraph_close",
+            },
+        ]);
+    });
+    test("autolinks", () => {
+        const md = MarkdownIt({ linkify: true });
+        md.use(wiki_icons_plugin);
+        const result = md.parse("https://google.com/:cpp:/foo", {});
+        expect(reduce(result)).to.deep.equal([
+            {
+                children: null,
+                content: "",
+                type: "paragraph_open",
+            },
+            {
+                children: [
+                    {
+                        children: null,
+                        content: "",
+                        type: "link_open",
+                    },
+                    {
+                        children: null,
+                        content: "https://google.com/:cpp:/foo",
+                        type: "text",
+                    },
+                    {
+                        children: null,
+                        content: "",
+                        type: "link_close",
+                    },
+                ],
+                content: "https://google.com/:cpp:/foo",
+                type: "inline",
+            },
+            {
+                children: null,
+                content: "",
+                type: "paragraph_close",
+            },
+        ]);
+    });
+});


### PR DESCRIPTION
This works around an issue related to using components in-line interfering with markdown and causing text to not be treated as paragraphs.