### PR TITLE
add 80 character column limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ You can assume C++20 as a minimum without explicitly pointing it out. For exampl
 
 Also, try to maintain consistent style in code. Some very rough points to touch on:
 
+- Columns should be no wider than 80 characters
 - Indent with four spaces
 - Braces on the same line, e.g. `int main() {`
 - Pointers/references on the left, e.g. `void* ptr`


### PR DESCRIPTION
#26 removed the 120 column limit.

I propose a limit of 80 columns for code samples in the wiki. The are two reasons for this:

1. The examples in the wiki are all relatively short and self-contained. You don't need deep indentation, and you don't need terribly long function names with lots of attributes and other decorations, usually. 80 really ought to be enough for our purposes.
2. People may consume the wiki on all sorts of devices. Phones, tablets, desktop computers, smaller laptop screens, etc. 120 columns is quite excessive, especially if you zoom in due to poor eyesight or other reasons. It's a fine limit for the Markdown sources, but those are basically always viewed in an IDE on a large screen, which we cannot assume for *every* reader of the wiki.