### PR TITLE
Discord link added to header

### DIFF
--- a/src/.vitepress/config.mts
+++ b/src/.vitepress/config.mts
@@ -216,7 +216,10 @@ export default defineConfig({
                 ],
             },
         ],
-        socialLinks: [{ icon: "github", link: "https://github.com/TCCPP/wiki" }],
+        socialLinks: [
+            { icon: "github", link: "https://github.com/TCCPP/wiki" },
+            { icon: "discord", link: "https://discord.gg/tccpp" },
+        ],
     },
     markdown: {
         lineNumbers: true,


### PR DESCRIPTION
This PR adds a link to the TCCPP discord, next to the github link in the header.

I think since TCCPP is a discord-based community, the ability to join should be not only on the main page, but from any page of the wiki.