### PR TITLE
Add link for Visual Studio Code with MINGW64 in getting started guide

### DIFF
--- a/src/resources/getting-started.md
+++ b/src/resources/getting-started.md
@@ -5,7 +5,7 @@
 To get started on Windows, select one of the following guides to set up a development environment.
 
 - [Visual Studio Community](/resources/dev-envs/visual-studio-community) (Recommended for Beginners)
-- Visual Studio Code with MINGW64 (TODO)
+- [Visual Studio Code with MINGW64](/resources/dev-envs/visual-studio-code-mingw)
 - [CLion](/resources/dev-envs/clion)
 
 ## Getting Started on Linux


### PR DESCRIPTION
Include a link to the Visual Studio Code with MINGW64 setup in the Windows getting started section of the guide.