### PR TITLE
Link CMake article from CLion article

### DIFF
--- a/src/resources/dev-envs/clion.md
+++ b/src/resources/dev-envs/clion.md
@@ -46,6 +46,6 @@ bottom that says "Hello, World!".
 ::: info
 
 CLion uses a build system called CMake. You can edit your build configuration in a file called `CMakeLists.txt`. This
-tutorial will not go into CMake, you can read our CMake article for more information.
+tutorial will not go into CMake, you can read our [CMake article](/resources/build-systems/cmake.md) for more information.
 
 :::

--- a/src/resources/dev-envs/clion.md
+++ b/src/resources/dev-envs/clion.md
@@ -46,6 +46,7 @@ bottom that says "Hello, World!".
 ::: info
 
 CLion uses a build system called CMake. You can edit your build configuration in a file called `CMakeLists.txt`. This
-tutorial will not go into CMake, you can read our [CMake article](/resources/build-systems/cmake.md) for more information.
+tutorial will not go into CMake, you can read our [CMake article](/resources/build-systems/cmake.md) for more
+information.
 
 :::


### PR DESCRIPTION
I linked the CMake article from the CLion article, this was intended anyways but the CMake article didn't exist when the CLion one was written.