### PR TITLE
Consistently refer WG21 N4868 as C++20 draft

### DIFF
--- a/wiki/resources/general/standards.md
+++ b/wiki/resources/general/standards.md
@@ -12,7 +12,7 @@ bot_article: |
 | --------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
 | :cpp: **C++26** | [Working Draft](https://eel.is/c++draft/)                                | [[N5032]](https://wg21.link/N5032)[^1]                                        |
 | :cpp: **C++23** | [[N4950]](https://timsong-cpp.github.io/cppwp/n4950/)                    | [[N4950]](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4950.pdf) |
-| :cpp: **C++20** | [[N4868]](https://timsong-cpp.github.io/cppwp/n4868/)                    | [[N4860]](https://isocpp.org/files/papers/N4860.pdf)                          |
+| :cpp: **C++20** | [[N4868]](https://timsong-cpp.github.io/cppwp/n4868/)                    | [[N4868]](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/n4868.pdf) |
 | :cpp: **C++17** | [[N4659]](https://timsong-cpp.github.io/cppwp/n4659/)                    | [[N4659]](http://open-std.org/jtc1/sc22/wg21/docs/papers/2017/n4659.pdf)      |
 | :cpp: **C++14** | [[N4140]](https://timsong-cpp.github.io/cppwp/n4140/)                    | [[N4140]](https://timsong-cpp.github.io/cppwp/n4140/draft.pdf)                |
 | :cpp: **C++11** | [[N3337]](https://timsong-cpp.github.io/cppwp/n3337/)                    | [[N3337]](http://open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3337.pdf)      |


### PR DESCRIPTION
It's unclear whether we used both N4860 and N4868 as C++20 drafts. Perhaps it would be more consistent to use the more editorially-fixed N4868 only.